### PR TITLE
[fix] 入力し直しに伴い、以前の正答入力が消去されるバグの改善

### DIFF
--- a/resources/js/answer_recoverer.js
+++ b/resources/js/answer_recoverer.js
@@ -1,14 +1,27 @@
+// 入力し直しのための正答復元
+
 document.addEventListener('DOMContentLoaded', function() {
-    // 正答の復元
-    if (oldAnswers.length > 0) {
-        var answersDiv = document.getElementById('answers');
-        answersDiv.innerHTML = ''; // ヒントをクリア
-        oldAnswers.forEach(function(answer) {
-            var textarea = document.createElement('textarea');
-            textarea.name = 'answers[]';
-            textarea.required = true;
-            textarea.value = answer;
-            answersDiv.appendChild(textarea);
-        });
+    if (oldAnswers.length === 0) {
+        return;
     }
+
+    // 正答コンテナを取得
+    const container = document.querySelector('#answer_container');
+    // コンテナ内をクリア
+    container.innerHTML = '';
+    oldAnswers.forEach(function(answer) {
+        // ブロックを作成
+        const newFormBlock = document.createElement('div');
+        newFormBlock.className = 'answer_block';
+        // ブロックをコンテナに追加
+        container.appendChild(newFormBlock);
+        // テキストエリアを作成
+        const textarea = document.createElement('textarea');
+        textarea.name = 'new_answer_text[]';
+        textarea.placeholder = '正答を入力';
+        textarea.required = true;
+        textarea.value = answer;
+        // ブロックに追加
+        newFormBlock.appendChild(textarea);
+    });
 });

--- a/resources/views/partials/question_create/answer_section.blade.php
+++ b/resources/views/partials/question_create/answer_section.blade.php
@@ -1,7 +1,8 @@
 <div id="answer_container">
     <p>正答</p>
     <div class="answer_block">
-        <textarea name="new_answer_text[]" placeholder="正答を入力"></textarea>
+        <textarea name="new_answer_text[]" placeholder="正答を入力" required></textarea>
+        @include('partials.new_image_upload_part', ['field_name' => 'new_answer_images', 'index' => 0])
     </div>
 </div>
 <button type="button" id="add_answer">+</button>

--- a/resources/views/questions/create.blade.php
+++ b/resources/views/questions/create.blade.php
@@ -6,8 +6,8 @@
 </head>
 <script>
     // 以前の入力内容(ヒント、正答)を復元
-    const oldHints = @json(old('hints', []));
-    const oldAnswers = @json(old('answers', []));
+    const oldHints = @json(old('hint_text', []));
+    const oldAnswers = @json(old('new_answer_text', []));
 </script>
 <form action="{{route('questions.store')}}" method="post" enctype="multipart/form-data">
     @csrf


### PR DESCRIPTION
エラーによって入力手戻りが発生した後、
以前の正答入力が消去されるバグがあった。
answer_recoverer.jsを変更してこのバグを改善した。